### PR TITLE
add an optional boolean to throw on missing stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,19 @@ void main() {
 }
 ```
 
-for more info check out the example module.
+### Optional: throw exceptions on missing stubs
+
+The `_$mock<T>()` method takes in an optional `bool` parameter named `enableThrowOnMissingStub`. This wraps the `Mock` object with the `throwOnMissingStub` method so that you get exceptions when you try to call a method that is not stubbed.
+
+
+```dart
+T mock<T>({bool throwOnMissingStub = false}) => _$mock<T>(enableThrowOnMissingStub: throwOnMissingStub);
+
+var myService = mock<MyService>(throwOnMissingStub: true);
+when(myService.doSomethingElse()).thenReturn(true);
+
+myService.doSomething(); // this will throw an exception
+myService.doSomethingElse(); // this will not throw an exception
+```
+
+For more info check out the example module.

--- a/example/test/mockito_builder_test.dart
+++ b/example/test/mockito_builder_test.dart
@@ -8,10 +8,12 @@ class ExampleUseCase3 {}
 void main() {
   ExampleUseCase exampleUseCase;
   ExampleUseCase2 exampleUseCase2;
+  ExampleUseCase exampleUseCaseThrows;
 
   setUp(() {
     exampleUseCase = mock();
     exampleUseCase2 = mock();
+    exampleUseCaseThrows = mock(throwOnMissingStub: true);
   });
   test('test 2 different example use cases', () {
     expect(exampleUseCase, isNotNull);
@@ -35,6 +37,15 @@ void main() {
       print(e.message);
     } catch (e) {
       fail("expected 'UnimplementedError'");
+    }
+  });
+
+  test('demonstrate throwOnMissingStub', () {
+    try {
+      exampleUseCaseThrows.example();
+      fail('expected exception');
+    } catch (e) {
+      print(e);
     }
   });
 }

--- a/example/test/test_utils/mocker.dart
+++ b/example/test/test_utils/mocker.dart
@@ -6,4 +6,4 @@ import 'package:mockito/mockito.dart';
 part 'mocker.g.dart';
 
 @GenerateMocker([ExampleUseCase, ExampleUseCase2])
-T mock<T>() => _$mock<T>();
+T mock<T>({bool throwOnMissingStub = false}) => _$mock<T>(enableThrowOnMissingStub: throwOnMissingStub);

--- a/example/test/test_utils/mocker.g.dart
+++ b/example/test/test_utils/mocker.g.dart
@@ -10,12 +10,20 @@ class _$MockExampleUseCase extends Mock implements ExampleUseCase {}
 
 class _$MockExampleUseCase2 extends Mock implements ExampleUseCase2 {}
 
-dynamic _$mock<T>() {
+dynamic _$mock<T>({bool enableThrowOnMissingStub = false}) {
   switch (T) {
     case ExampleUseCase:
-      return _$MockExampleUseCase();
+      final mock = _$MockExampleUseCase();
+      if (enableThrowOnMissingStub) {
+        throwOnMissingStub(mock);
+      }
+      return mock;
     case ExampleUseCase2:
-      return _$MockExampleUseCase2();
+      final mock = _$MockExampleUseCase2();
+      if (enableThrowOnMissingStub) {
+        throwOnMissingStub(mock);
+      }
+      return mock;
     default:
       throw UnimplementedError(
           '''Error, a mock class for '$T' has not been generated yet.

--- a/lib/src/dartbuilders/mockito_builder_dart_builder.dart
+++ b/lib/src/dartbuilders/mockito_builder_dart_builder.dart
@@ -31,7 +31,11 @@ Finally run the build command: \'flutter packages pub run build_runner build\'.'
     list.add(Code("switch(T) {"));
     mockitoConfig.mockDefs.forEach((mockDef) {
       list.add(Code("case ${mockDef.type}:"));
-      list.add(Code("return ${mockDef.targetClassName}();"));
+      list.add(Code("final mock = ${mockDef.targetClassName}();"));
+      list.add(Code("if (enableThrowOnMissingStub) {"));
+      list.add(Code("throwOnMissingStub(mock);"));
+      list.add(Code("}"));
+      list.add(Code("return mock;"));
     });
     list.add(Code(
         "default: throw UnimplementedError(\'\'\'${createUnimplementedErrorMessage(mockitoConfig)}\'\'\');"));
@@ -41,10 +45,18 @@ Finally run the build command: \'flutter packages pub run build_runner build\'.'
 
   Method buildMockerMethod(MockitoConfig mockitoConfig) {
     final name = mockitoConfig.mockerName;
+    var throwOnMissingStubBuilder = ParameterBuilder();
+    throwOnMissingStubBuilder.name = "enableThrowOnMissingStub";
+    throwOnMissingStubBuilder.defaultTo = Code("false");
+    throwOnMissingStubBuilder.named = true;
+    throwOnMissingStubBuilder.type = refer('bool');
+    final throwOnMissingStub = throwOnMissingStubBuilder.build();
+
     return Method((b) => b
       ..name = "_\$$name"
       ..returns = refer('dynamic')
       ..types.add(refer("T"))
+      ..optionalParameters.add(throwOnMissingStub)
       ..body = createSwitchStatement(mockitoConfig));
   }
 }


### PR DESCRIPTION
The method takes in a `Mock` so it's easier to set this up when initializing the mock itself. I added an optional boolean `enableThrowOnMissingStub`  to indicate that you want to wrap your mock with this behaviour.